### PR TITLE
gitlab: Add test job for non-main branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,22 +1,44 @@
-image: python:bullseye
+image: python:3.11-bookworm
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+cache:
+  paths:
+    - ".venv/"
+
+before_script:
+  - |
+    apt-get update && \
+      export DEBIAN_FRONTEND=noninteractive && \
+      apt-get -y install --no-install-recommends \
+    python3-brotli \
+    python3-cffi \
+    python3-pip \
+    zip
+  - pip install poetry==1.5.1
+  - poetry config virtualenvs.in-project true
+  - poetry install --no-root
+
+# Build and publish main branch to GitLab pages
 pages:
+  stage: deploy
   script:
-    - |
-      apt-get update && \
-        export DEBIAN_FRONTEND=noninteractive && \
-        apt-get -y install --no-install-recommends \
-      python3-brotli \
-      python3-cffi \
-      python3-pip \
-      zip
-    - pip install poetry==1.5.1
-    - poetry config virtualenvs.in-project true
-    - poetry install --no-root
     - poetry run mkdocs build -d public
-
   artifacts:
     paths:
       - public
-  only:
-    - main
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+
+# Build without publishing to detect breaking changes on non-main branches
+test:
+  stage: test
+  script:
+    - poetry run mkdocs build -d test
+  artifacts:
+    paths:
+      - test
+  rules:
+    - if: $CI_COMMIT_BRANCH != "main"


### PR DESCRIPTION
With the current setup, no build runs for non-`main` branches. So breaking changes go undetected before merges.

This change adds a `test` job running on non-`main` branches to allow CI to run before merging. It doesn't publish the result to GitLab pages as it's using another output directory.